### PR TITLE
Ability to update CNAME record.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ vagrant-aws-route53
 
 A Vagrant plugin assigns the public IP of the instance which vagrant-aws provider created to a specific Route 53 record set. 
 
-### Assigns the IP when
+### Assigns the IP / the public DNS name when (A record / CNAME record)
 
 * initial ```vagrant up```
 * ```vagrant up``` the halted instance. 
@@ -27,6 +27,11 @@ A Vagrant plugin assigns the public IP of the instance which vagrant-aws provide
 ```zsh
 $ vagrant install vagrant-aws-route53
 ```
+
+## Record Set Options
+
+* %w(test.oogatta.com. A) - uses public IP of EC2 Instance 
+* %w(test.oogatta.com. CNAME) - uses public DNS name of EC2 Instance (within AWS datacenter points to internal IP, otherwise to public IP)
 
 ## Config
 

--- a/lib/vagrant-aws-route53/action/set_ip.rb
+++ b/lib/vagrant-aws-route53/action/set_ip.rb
@@ -21,8 +21,8 @@ module VagrantPlugins
             instance_id:       instance_id,
             hosted_zone_id:    hosted_zone_id,
             record_set:        record_set,
-          ) do |instance_id, pubilic_ip, record_set|
-            environment[:ui].info("#{instance_id}'s #{pubilic_ip} has been assigned to #{record_set[0]}[#{record_set[1]}]")
+          ) do |instance_id, public_ip, record_set|
+            environment[:ui].info("#{instance_id}'s #{public_ip} has been assigned to #{record_set[0]}[#{record_set[1]}]")
           end
 
           @app.call(environment)

--- a/vagrant-aws-route53.gemspec
+++ b/vagrant-aws-route53.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.authors       = 'Naohiro Oogatta'
   s.email         = 'oogatta@gmail.com'
   s.homepage      = 'https://github.com/oogatta/vagrant-aws-route53'
-  s.summary       = 'Assigns IPs of Vagrant AWS instances to route 53.'
-  s.description   = 'A Vagrant plugin assigns the IP of the instance which vagrant-aws provider created to a specific Route 53 record set.'
+  s.summary       = 'Assigns IPs or public DNS name of Vagrant AWS instances to route 53.'
+  s.description   = 'A Vagrant plugin assigns the IP or public DNS name of the instance which vagrant-aws provider created to a specific Route 53 record set.'
   s.require_path  = 'lib'
   s.files         = Dir.glob('lib/**/*') + %w(LICENSE README.md)
 


### PR DESCRIPTION
Hi, 

I've been using your module for quite long time. Today I've decided to add ability to update CNAME records also. It appeared to me more suitable to point to EC2's public DNS record, like ec2-0-0-0-0.zone.compute.amazonaws.com than to IP. The advantage is, the target is EC2's private IP inside AWS data center and public IP in outer world. 

Feel free to pull if you consider it useful.

Pepa